### PR TITLE
Proposal for faster iteration over the weights of edges

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 1.0
 LightGraphs 1.0
+DataStructures


### PR DESCRIPTION
This PR is more of a proposal on how a lot of algorithms using `SimpleWeightedGraphs` could be made faster. It most certainly should not be merged in this form.

The idea is, that a lot of algorithms contain code of the form
```
for v in neighbors(g, u)
  dist = distmx[u, v]
  ... do something with dist
```
`distmx` is by default equal to `weights(g)`. This is then inefficient, because in every iteration one has an array access of complexity  `O(log(n))`. By simply iterating over the row of this matrix this can be avoided.

I have added some benchmarks. One might notice that I also used another package called `SimpleValueGraphs.jl`. At the moment this is still wip and the latest version of it on github is not up to date as I am still fighting with design questions and type instability.

The reason for using this package is, that it made it easier to initialize random edge weights. I also did some benchmarks on these graphs. In theory `SimpleWeightedGraphs`  should be slightly faster, but this is not the case here.

```
using BenchmarkTools, LightGraphs, SimpleWeightedGraphs, SimpleValueGraphs, SNAPDatasets, Random
fb = SimpleGraph{Int32}(loadsnap(:facebook_combined));
rng = MersenneTwister(0);
gv = ValueGraph((s,d) -> 0.1 + rand(rng), fb);
gw = SimpleWeightedGraph(weights(gv))

# prim_mst

## old 
julia> @btime prim_mst(gw, weights(gw));
  10.194 ms (49508 allocations: 2.91 MiB)

## new
julia> @btime prim_mst(gw);
  4.900 ms (4095 allocations: 2.16 MiB)

## SimpleValueGraphs
julia> @btime prim_mst(gv);
  4.134 ms (54 allocations: 342.42 KiB)


# kruskal_mst

## old
julia> @btime kruskal_mst(gw, weights(gw));
  12.679 ms (35 allocations: 8.94 MiB)

## new
julia> @btime kruskal_mst(gw);
  11.086 ms (35 allocations: 8.94 MiB)

## SimpleValueGraphs
julia> @btime kruskal_mst(gv);
  10.997 ms (20 allocations: 4.16 MiB)


# a_star

## old
julia> @btime a_star(gw, 1, nv(gw), weights(gw));
  15.674 s (127801243 allocations: 3.65 GiB)

## new
julia> @btime a_star(gw, 1, nv(gw));
  15.532 s (127801243 allocations: 3.65 GiB)

## SimpleValueGraphs
julia> @btime a_star(gv, 1, nv(gv));
  5.939 s (33768291 allocations: 802.16 MiB)


# dijikstra_shortest_paths

## old
julia> @btime dijkstra_shortest_paths(gw, 1, weights(gw));
  11.747 ms (4089 allocations: 2.16 MiB)

## new
julia> @btime dijkstra_shortest_paths(gw, 1);
  3.482 ms (4089 allocations: 2.16 MiB)

## SimpleValueGraphs
julia> @btime dijkstra_shortest_paths(gv, 1);
  3.122 ms (50 allocations: 451.83 KiB)
```