### PR TITLE
use views for neighbors, add API to get neighborhood weights

### DIFF
--- a/src/SimpleWeightedGraphs.jl
+++ b/src/SimpleWeightedGraphs.jl
@@ -33,7 +33,8 @@ export
     get_weight,
     WGraph,
     WDiGraph,
-    SWGFormat
+    SWGFormat,
+    outneighbor_weights
 
 include("simpleweightededge.jl")
 
@@ -114,8 +115,21 @@ end
 
 function outneighbors(g::AbstractSimpleWeightedGraph, v::Integer)
     mat = g.weights
-    return mat.rowval[mat.colptr[v]:mat.colptr[v+1]-1]
+    return view(mat.rowval, mat.colptr[v]:mat.colptr[v+1]-1)
 end
+
+@doc_str """
+    neighbor_weights(g::SimpleWeightedGraph, v)
+
+    Returns the weights of (out-)neighbors(g, v). The pairs of outneighbors and their 
+    weights can be obtained by `zip(neighbors(g,v), neighbor_weights(g,v))`
+"""
+function neighbor_weights(g::SimpleWeightedGraph, v::Integer)
+        mat = g.weights
+        return view(mat.nzval, mat.colptr[v]:mat.colptr[v+1]-1)
+end
+
+
 
 get_weight(g::AbstractSimpleWeightedGraph, u::Integer, v::Integer) = g.weights[v, u]
 

--- a/test/simpleweightedgraph.jl
+++ b/test/simpleweightedgraph.jl
@@ -47,6 +47,15 @@ using SimpleWeightedGraphs
     @test_logs (:warn, "Note: adding edges with a zero weight to this graph type has no effect.") add_edge!(gc, 4, 1, 0.0)
     @test !(add_edge!(gc, 4, 1, 0.0))
 
+    function test_neighborweights(g::SimpleWeightedGraph)
+        for u in vertices(g)
+            for (v,d) in zip(neighbors(g,u), neighbor_weights(g, u))
+                d == get_weight(g, u, v) || return false
+            end
+        end
+        true
+    end
+
     for g in testgraphs(gx)
         @test @inferred(vertices(g)) == 1:4
         @test SimpleWeightedEdge(2,3) in edges(g)
@@ -54,6 +63,7 @@ using SimpleWeightedGraphs
         @test @inferred(outneighbors(g,2)) == inneighbors(g,2) == neighbors(g,2)
         @test @inferred(has_edge(g, 2, 3))
         @test @inferred(has_edge(g, 3, 2))
+        @test test_neighborweights(g)
 
         gc = copy(g)
         @test @inferred(add_edge!(gc, 4=>1)) && gc == SimpleWeightedGraph(CycleGraph(4))


### PR DESCRIPTION
This uses views for neighbors, instead of taking a copy, and adds an API to get weights for neighbors.

In theory this could be done for digraphs as well. However, digraphs should store both `weights` and its transpose, in order to get faster access; otherwise, there is no point.

I am currently no user of digraphs. I think a 2 x increase in memory consumption is an acceptable price for a ~10 x faster non-allocating `neighbors_in`, but that would be a separate PR, preferably by users of digraphs.

This is complementary to https://github.com/JuliaGraphs/SimpleWeightedGraphs.jl/pull/44 . 

If the API `outedgeweights` of that PR gets accepted first, then I'd rebase. Otherwise, that PR should rebase on top of `neighbor_weights`. 