### PR TITLE
Use view to compute neighbors

### DIFF
--- a/src/SimpleWeightedGraphs.jl
+++ b/src/SimpleWeightedGraphs.jl
@@ -116,7 +116,7 @@ end
 
 function outneighbors(g::AbstractSimpleWeightedGraph, v::Integer)
     mat = g.weights
-    return mat.rowval[mat.colptr[v]:mat.colptr[v+1]-1]
+    return view(mat.rowval, mat.colptr[v]:mat.colptr[v+1]-1)
 end
 
 get_weight(g::AbstractSimpleWeightedGraph, u::Integer, v::Integer) = g.weights[v, u]


### PR DESCRIPTION
We had mentioned this on slack at some point: my feeling is that in general it should be more performant to  use a view to compute the neighbors to reduce allocations.