### PR TITLE
Clarification for edge vs node weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/JuliaGraphs/SimpleWeightedGraphs.jl.svg?branch=master)](https://travis-ci.org/JuliaGraphs/SimpleWeightedGraphs.jl)
 [![codecov.io](http://codecov.io/github/JuliaGraphs/SimpleWeightedGraphs.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaGraphs/SimpleWeightedGraphs.jl?branch=master)
 
-Weighted Graphs for [LightGraphs.jl](https://github.com/JuliaGraphs/LightGraphs.jl).
+Edge-Weighted Graphs for [LightGraphs.jl](https://github.com/JuliaGraphs/LightGraphs.jl).
 
 Usage:
 ```


### PR DESCRIPTION
https://github.com/JuliaGraphs/SimpleWeightedGraphs.jl/issues/54

To clarify that the package is for edge-weighted graphs; node-weighted graphs unsupported.

One-word change to README.md